### PR TITLE
zephyr: update include paths to use <zephyr/...>

### DIFF
--- a/platform/zephyr/include/chre/target_platform/atomic_base.h
+++ b/platform/zephyr/include/chre/target_platform/atomic_base.h
@@ -17,7 +17,7 @@
 #ifndef CHRE_PLATFORM_ZEPHYR_ATOMIC_BASE_H_
 #define CHRE_PLATFORM_ZEPHYR_ATOMIC_BASE_H_
 
-#include <sys/atomic.h>
+#include <zephyr/sys/atomic.h>
 
 namespace chre {
 

--- a/platform/zephyr/include/chre/target_platform/atomic_base_impl.h
+++ b/platform/zephyr/include/chre/target_platform/atomic_base_impl.h
@@ -17,7 +17,7 @@
 #ifndef CHRE_PLATFORM_ZEPHYR_ATOMIC_BASE_IMPL_H_
 #define CHRE_PLATFORM_ZEPHYR_ATOMIC_BASE_IMPL_H_
 
-#include <sys/atomic.h>
+#include <zephyr/sys/atomic.h>
 
 #include "chre/platform/atomic.h"
 

--- a/platform/zephyr/include/chre/target_platform/condition_variable_base.h
+++ b/platform/zephyr/include/chre/target_platform/condition_variable_base.h
@@ -17,7 +17,7 @@
 #ifndef CHRE_PLATFORM_ZEPHYR_CONDITION_VARIABLE_BASE_H_
 #define CHRE_PLATFORM_ZEPHYR_CONDITION_VARIABLE_BASE_H_
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 namespace chre {
 

--- a/platform/zephyr/include/chre/target_platform/fatal_error.h
+++ b/platform/zephyr/include/chre/target_platform/fatal_error.h
@@ -17,7 +17,7 @@
 #ifndef CHRE_PLATFORM_ZEPHYR_FATAL_ERROR_H_
 #define CHRE_PLATFORM_ZEPHYR_FATAL_ERROR_H_
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #define FATAL_ERROR_QUIT() k_panic()
 

--- a/platform/zephyr/include/chre/target_platform/init.h
+++ b/platform/zephyr/include/chre/target_platform/init.h
@@ -17,7 +17,7 @@
 #ifndef CHRE_PLATFORM_ZEPHYR_INIT_H_
 #define CHRE_PLATFORM_ZEPHYR_INIT_H_
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 namespace chre {
 

--- a/platform/zephyr/include/chre/target_platform/init.h
+++ b/platform/zephyr/include/chre/target_platform/init.h
@@ -17,7 +17,7 @@
 #ifndef CHRE_PLATFORM_ZEPHYR_INIT_H_
 #define CHRE_PLATFORM_ZEPHYR_INIT_H_
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 namespace chre {
 

--- a/platform/zephyr/include/chre/target_platform/log.h
+++ b/platform/zephyr/include/chre/target_platform/log.h
@@ -17,7 +17,7 @@
 #ifndef CHRE_PLATFORM_ZEPHYR_LOG_H_
 #define CHRE_PLATFORM_ZEPHYR_LOG_H_
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(chre, CONFIG_CHRE_LOG_LEVEL);
 
 /** Map CHRE's LOGE to Zephyr's LOG_ERR */

--- a/platform/zephyr/include/chre/target_platform/mutex_base.h
+++ b/platform/zephyr/include/chre/target_platform/mutex_base.h
@@ -17,7 +17,7 @@
 #ifndef CHRE_PLATFORM_ZEPHYR_MUTEX_BASE_H_
 #define CHRE_PLATFORM_ZEPHYR_MUTEX_BASE_H_
 
-#include <sys/mutex.h>
+#include <zephyr/sys/mutex.h>
 
 namespace chre {
 

--- a/platform/zephyr/log_module.c
+++ b/platform/zephyr/log_module.c
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(chre, CONFIG_CHRE_LOG_LEVEL);


### PR DESCRIPTION
Zephyr has prefixed all of its includes with <zephyr/...>. While the old
mode can still be used (CONFIG_LEGACY_INCLUDE_PATH) and is still enabled
by default, it's better to be prepared for its removal in the future.