### PR TITLE
zephyr: Add buffer_base.cc to Zephyr builds

### DIFF
--- a/platform/zephyr/CMakeLists.txt
+++ b/platform/zephyr/CMakeLists.txt
@@ -53,6 +53,7 @@ if(CONFIG_CHRE)
       "${CHRE_DIR}/core/timer_pool.cc"
       "${CHRE_DIR}/platform/shared/version.cc"
       "${CHRE_DIR}/platform/shared/system_time.cc"
+      "${CHRE_DIR}/util/buffer_base.cc"
       "${CHRE_DIR}/util/dynamic_vector_base.cc"
   )
   zephyr_linker_sources(SECTIONS linker_chre.ld)


### PR DESCRIPTION
Fix Zephyr build issue found at
https://github.com/zephyrproject-rtos/zephyr/actions/runs/3458875712/jobs/5909874446#step:13:342

Tested via:
```
$ ./scripts/twister -c -i -v -p esp32s2_saola -s zephyr/samples/modules/chre/sample.modules.chre
```