### PR TITLE
zephyr: Make CONFIG_CHRE select CONFIG_REQUIRES_FULL_LIBCPP

### DIFF
--- a/platform/zephyr/Kconfig
+++ b/platform/zephyr/Kconfig
@@ -6,6 +6,7 @@ config ZEPHYR_CHRE_MODULE
 
 menuconfig CHRE
 	bool "CHRE Support"
+	select REQUIRES_FULL_LIBCPP
 	help
 	  This option enables the CHRE library.
 


### PR DESCRIPTION
This commit makes the Kconfig `CONFIG_CHRE` symbol select the `CONFIG_REQUIRES_FULL_LIBCPP` symbol because the CHRE library requires a fully featured C++ standard library.

Signed-off-by: Stephanos Ioannidis <stephanos.ioannidis@nordicsemi.no>